### PR TITLE
Fix Linux build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,6 @@ set(HEADER_FILES
   hlslang/Include/PoolAlloc.h
   hlslang/Include/Types.h
   hlslang/MachineIndependent/SymbolTable.h
-  #hlslang/MachineIndependent/unistd.h
 )
 source_group("Header Files" FILES ${HEADER_FILES})
 
@@ -69,7 +68,6 @@ set(MACHINE_INDEPENDENT_FILES
   hlslang/MachineIndependent/RemoveTree.h
   hlslang/MachineIndependent/SymbolTable.cpp
   hlslang/MachineIndependent/SymbolTable.h
-  #hlslang/MachineIndependent/unistd.h
   hlslang/MachineIndependent/ConstantFolding.cpp
 )
 

--- a/hlslang.vcxproj
+++ b/hlslang.vcxproj
@@ -356,7 +356,6 @@ rename %(RootDir)%(Directory)%(Filename)_tab.c Gen_%(Filename)_tab.cpp
     <ClInclude Include="hlslang\Include\PoolAlloc.h" />
     <ClInclude Include="hlslang\MachineIndependent\SymbolTable.h" />
     <ClInclude Include="hlslang\Include\Types.h" />
-    <ClInclude Include="hlslang\MachineIndependent\unistd.h" />
     <ClInclude Include="include\hlsl2glsl.h" />
     <ClInclude Include="hlslang\GLSLCodeGen\glslCommon.h" />
     <ClInclude Include="hlslang\GLSLCodeGen\glslFunction.h" />

--- a/hlslang.vcxproj.filters
+++ b/hlslang.vcxproj.filters
@@ -210,9 +210,6 @@
     <ClInclude Include="hlslang\Include\Types.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="hlslang\MachineIndependent\unistd.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="include\hlsl2glsl.h">
       <Filter>include</Filter>
     </ClInclude>

--- a/hlslang.xcodeproj/project.pbxproj
+++ b/hlslang.xcodeproj/project.pbxproj
@@ -81,7 +81,6 @@
 		3AC10E190AF106C40045E29C /* ParseHelper.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = ParseHelper.h; path = hlslang/MachineIndependent/ParseHelper.h; sourceTree = "<group>"; };
 		3AC10E1B0AF106C40045E29C /* RemoveTree.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = RemoveTree.h; path = hlslang/MachineIndependent/RemoveTree.h; sourceTree = "<group>"; };
 		3AC10E1C0AF106C40045E29C /* SymbolTable.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = SymbolTable.h; path = hlslang/MachineIndependent/SymbolTable.h; sourceTree = "<group>"; };
-		3AC10E1D0AF106C40045E29C /* unistd.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = unistd.h; path = hlslang/MachineIndependent/unistd.h; sourceTree = "<group>"; };
 		3AC10E260AF106F40045E29C /* HLSL2GLSL.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; name = HLSL2GLSL.cpp; path = hlslang/MachineIndependent/HLSL2GLSL.cpp; sourceTree = "<group>"; };
 		3AC10E270AF106F40045E29C /* InfoSink.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; name = InfoSink.cpp; path = hlslang/MachineIndependent/InfoSink.cpp; sourceTree = "<group>"; };
 		3AC10E280AF106F40045E29C /* Initialize.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; name = Initialize.cpp; path = hlslang/MachineIndependent/Initialize.cpp; sourceTree = "<group>"; };
@@ -246,7 +245,6 @@
 				3AC10E190AF106C40045E29C /* ParseHelper.h */,
 				3AC10E1B0AF106C40045E29C /* RemoveTree.h */,
 				3AC10E1C0AF106C40045E29C /* SymbolTable.h */,
-				3AC10E1D0AF106C40045E29C /* unistd.h */,
 			);
 			name = Headers;
 			sourceTree = "<group>";

--- a/hlslang/GLSLCodeGen/glslCommon.cpp
+++ b/hlslang/GLSLCodeGen/glslCommon.cpp
@@ -5,6 +5,9 @@
 
 #include "glslStruct.h"
 
+#include <string.h>
+#include <stdlib.h>
+
 /// Table to convert GLSL variable types to strings
 const char typeString[EgstTypeCount][32] = 
 {

--- a/hlslang/MachineIndependent/hlslang.l
+++ b/hlslang/MachineIndependent/hlslang.l
@@ -31,6 +31,8 @@ I           [uUlL]
 
 %option nounput 
 %{
+#define YY_NO_UNISTD_H
+
 #include <stdio.h>
 #include <stdlib.h>
 #include "ParseHelper.h"

--- a/hlslang/MachineIndependent/unistd.h
+++ b/hlslang/MachineIndependent/unistd.h
@@ -1,1 +1,0 @@
-// empty, just needs to exist for generated lex/yacc files

--- a/hlslang/OSDependent/Linux/ossource.cpp
+++ b/hlslang/OSDependent/Linux/ossource.cpp
@@ -6,60 +6,10 @@
 // This file contains the Linux specific functions
 //
 #include "osinclude.h"
-#include "InitializeDll.h"
 
 #if !(defined(linux))
 #error Trying to build a Linux specific file in a non-Linux build.
 #endif
-
-
-//
-// Thread cleanup
-//
-
-//
-// Wrapper for Linux call to DetachThread.  This is required as pthread_cleanup_push() expects 
-// the cleanup routine to return void.
-// 
-void DetachThreadLinux(void *)
-{
-	DetachThread();
-}
-
-
-//
-// Registers cleanup handler, sets cancel type and state, and excecutes the thread specific
-// cleanup handler.  This function will be called in the Standalone.cpp for regression 
-// testing.  When OpenGL applications are run with the driver code, Linux OS does the 
-// thread cleanup.
-// 
-void OS_CleanupThreadData(void)
-{
-	int old_cancel_state, old_cancel_type;
-	void *cleanupArg = NULL;
-
-	//
-	// Set thread cancel state and push cleanup handler.
-	//
-	pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, &old_cancel_state);
-	pthread_cleanup_push(DetachThreadLinux, (void *) cleanupArg);
-
-	//
-	// Put the thread in deferred cancellation mode.
-	//
-	pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED, &old_cancel_type);
-
-	//
-	// Pop cleanup handler and execute it prior to unregistering the cleanup handler.
-	//
-	pthread_cleanup_pop(1);
-
-	//
-	// Restore the thread's previous cancellation mode.
-	//
-	pthread_setcanceltype(old_cancel_state, NULL);
-}
-
 
 //
 // Thread Local Storage Operations


### PR DESCRIPTION
Add missing include files and remove outdated functions from OS-specific code.
Instead of putting a dummy unistd.h on the include path, disable its inclusion the right way.
