### PR TITLE
since only Win32 CMake has a registry write command, wrap with #ifdef so...

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,9 @@ set(MACHINE_INDEPENDENT_CPP_FILES
 source_group("Machine Independent\\CPP" FILES ${MACHINE_INDEPENDENT_CPP_FILES})
 
 
-EXEC_PROGRAM(${CMAKE_COMMAND} ARGS "-E write_regv \"${hkey}\" \"${dir}\"")
+if (WIN32)
+  EXEC_PROGRAM(${CMAKE_COMMAND} ARGS "-E write_regv \"${hkey}\" \"${dir}\"")
+endif ()
 
 
 set(MACHINE_INDEPENDENT_GENERATED_SOURCE_FILES


### PR DESCRIPTION
... no errors are generated.

write_regv appears to be a write to registry command, which obviously only exists on Windows CMake. wrap to avoid ugly error message by CMake.