### PR TITLE
Win32 compile fix

### DIFF
--- a/hlslang.vcxproj.filters
+++ b/hlslang.vcxproj.filters
@@ -121,9 +121,6 @@
     <ClCompile Include="hlslang\GLSLCodeGen\typeSamplers.cpp">
       <Filter>GLSL Code Gen</Filter>
     </ClCompile>
-    <ClCompile Include="hlslang\OSDependent\Windows\main.cpp">
-      <Filter>OSDependent\Windows</Filter>
-    </ClCompile>
     <ClCompile Include="hlslang\OSDependent\Windows\ossource.cpp">
       <Filter>OSDependent\Windows</Filter>
     </ClCompile>

--- a/hlslang/MachineIndependent/Intermediate.cpp
+++ b/hlslang/MachineIndependent/Intermediate.cpp
@@ -12,6 +12,7 @@
 #include "ParseHelper.h"
 #include <float.h>
 #include <limits.h>
+#include <algorithm>
 
 static TPrecision GetHigherPrecision (TPrecision left, TPrecision right) {
 	return left > right ? left : right;


### PR DESCRIPTION
1. There is no "main.cpp" in the OSDependent/ directory.
2. VS 2013 does not pull in std::min and std::max without including <algorithm> in Intermediate.cpp
3. YY_NO_UNISTD_H seems to not be implemented/respected by the included bison and flex EXEs, and since this directory is already in the includes, add a dummy "unistd.h" so that compiles work.