### PR TITLE
Fix incorrectly promoting sub-nodes in non-parameter list aggregates

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,13 @@
 hlsl2glsl Change Log
 =========================
 
+2015 07
+-------
+
+Fixes:
+
+* Fixed a case where code such as functionCall( tex2D(tex, uv) ) would fail to compile.
+
 2015 06
 -------
 

--- a/hlslang/MachineIndependent/ParseHelper.cpp
+++ b/hlslang/MachineIndependent/ParseHelper.cpp
@@ -1570,7 +1570,11 @@ TIntermNode* TParseContext::promoteFunctionArguments( TIntermNode *node, const T
    TIntermTyped *tNode = 0;
    TIntermNode *ret = 0;
 
-   if (aggNode)
+   // if the node is an aggregate list of parameters to a function call, promote
+   // each individual subnode. Note the Op could be EOpNull too while processing,
+   // the important distinction is we should not include other aggregates like
+   // EOpTex2DLod
+   if (aggNode && aggNode->getOp() <= EOpParameters)
    {
       //This is a function call with multiple arguments
       TNodeArray &seq = aggNode->getNodes();

--- a/tests/fragment-120/matrix-out.txt
+++ b/tests/fragment-120/matrix-out.txt
@@ -19,9 +19,9 @@ void vec_upcast( in vec4 f ) {
 }
 #line 16
 vec4 xlat_main(  ) {
-    vec_upcast( vec4( 0.0));
+    vec_upcast( vec4( vec2( 0.0), 0.0, 0.0));
     #line 19
-    vec_downcast( vec2( 1.0));
+    vec_downcast( vec2( vec4( 1.0)));
     mat4 m = mat4( val);
     mat4x2 m2 = mat4x2( m);
     #line 23

--- a/tests/fragment/tex2d-func-call-in.txt
+++ b/tests/fragment/tex2d-func-call-in.txt
@@ -1,0 +1,11 @@
+#line 1 "tex2dlod-in.txt" 
+sampler2D tex;
+
+float test(float a)
+{
+	return tex2Dlod (tex, float4(a.xx,0,0));
+}
+
+half4 main (float4 uv : TEXCOORD0) : COLOR0 {
+	return test(tex2Dlod (tex, float4(uv.xy,0,0)));
+}

--- a/tests/fragment/tex2d-func-call-out.txt
+++ b/tests/fragment/tex2d-func-call-out.txt
@@ -1,0 +1,25 @@
+#extension GL_ARB_shader_texture_lod : require
+vec4 xll_tex2Dlod(sampler2D s, vec4 coord) {
+   return texture2DLod( s, coord.xy, coord.w);
+}
+#line 1
+uniform sampler2D tex;
+#line 3
+float test( in float a ) {
+    #line 5
+    return float( xll_tex2Dlod( tex, vec4( vec2( a), 0.0, 0.0)));
+}
+#line 8
+vec4 xlat_main( in vec4 uv ) {
+    #line 9
+    return vec4( test( float( xll_tex2Dlod( tex, vec4( uv.xy, 0.0, 0.0)))));
+}
+varying vec4 xlv_TEXCOORD0;
+void main() {
+    vec4 xl_retval;
+    xl_retval = xlat_main( vec4(xlv_TEXCOORD0));
+    gl_FragData[0] = vec4(xl_retval);
+}
+
+// uniforms:
+// tex:<none> type 25 arrsize 0

--- a/tests/fragment/tex2d-func-call-outES.txt
+++ b/tests/fragment/tex2d-func-call-outES.txt
@@ -1,0 +1,25 @@
+#extension GL_EXT_shader_texture_lod : require
+vec4 xll_tex2Dlod(sampler2D s, vec4 coord) {
+   return texture2DLodEXT( s, coord.xy, coord.w);
+}
+#line 1
+uniform sampler2D tex;
+#line 3
+highp float test( in highp float a ) {
+    #line 5
+    return float( xll_tex2Dlod( tex, vec4( vec2( a), 0.0, 0.0)));
+}
+#line 8
+mediump vec4 xlat_main( in highp vec4 uv ) {
+    #line 9
+    return vec4( test( float( xll_tex2Dlod( tex, vec4( uv.xy, 0.0, 0.0)))));
+}
+varying highp vec4 xlv_TEXCOORD0;
+void main() {
+    mediump vec4 xl_retval;
+    xl_retval = xlat_main( vec4(xlv_TEXCOORD0));
+    gl_FragData[0] = vec4(xl_retval);
+}
+
+// uniforms:
+// tex:<none> type 25 arrsize 0


### PR DESCRIPTION
This should fix the odd case where the promote function was incorrectly stepping inside built-in function calls (as aggregates) expecting them to be parameter lists, and getting confused when the number of nodes didn't match the arguments to the function it was trying to promote to.