### PR TITLE
Fix parser and lexer scripts to work with modern Bison/Flex.

### DIFF
--- a/hlslang/MachineIndependent/hlslang.l
+++ b/hlslang/MachineIndependent/hlslang.l
@@ -46,14 +46,9 @@ I           [uUlL]
 int yy_input(char* buf, int max_size);
 static TSourceLoc lexlineno = { 0, 0 };
 
-#ifdef _WIN32
-    extern int yyparse(TParseContext&);
-    #define YY_DECL int yylex(YYSTYPE* pyylval, TParseContext& parseContext)    
-#else
-    extern int yyparse(void*);
-    #define YY_DECL int yylex(YYSTYPE* pyylval, void* parseContextLocal)
-    #define parseContext (*((TParseContext*)(parseContextLocal)))		
-#endif
+extern int yyparse(TParseContext&);
+#define YY_DECL int yylex(YYSTYPE* pyylval, TParseContext& parseContext)    
+
  
 #define YY_INPUT(buf,result,max_size) (result = yy_input(buf, max_size))
 
@@ -465,12 +460,8 @@ int PaParseString(char* source, TParseContext& parseContextLocal, Hlsl2Glsl_Pars
    
     if (sourceLen >= 0)
 	{
-        int ret;
-        #ifdef _WIN32
-            ret = yyparse(parseContextLocal);            
-        #else
-            ret = yyparse((void*)(&parseContextLocal));
-        #endif
+        int ret = yyparse(parseContextLocal);    
+
         if (parseContextLocal.recoveredFromError || parseContextLocal.numErrors > 0)
              result = 1;
         else
@@ -488,7 +479,7 @@ int PaParseString(char* source, TParseContext& parseContextLocal, Hlsl2Glsl_Pars
 	return result;
 }
 
-void yyerror(const char *s)
+void yyerror(TParseContext& parseContext, const char *s)
 {
 
 	GlobalParseContext->error(lexlineno, "syntax error", GlobalParseContext->AfterEOF ? "" : yytext, s, "");

--- a/hlslang/MachineIndependent/hlslang.y
+++ b/hlslang/MachineIndependent/hlslang.y
@@ -25,20 +25,7 @@ Jutta Degener, 1995
 #include "ParseHelper.h"
 #include "../../include/hlsl2glsl.h"
 
-#ifdef _WIN32
-    #define YYPARSE_PARAM parseContext
-    #define YYPARSE_PARAM_DECL TParseContext&
-    #define YY_DECL int yylex(YYSTYPE* pyylval, TParseContext& parseContext)
-    #define YYLEX_PARAM parseContext
-	void yyerror(const char*);
-#else
-    #define YYPARSE_PARAM parseContextLocal
-    #define parseContext (*((TParseContext*)(parseContextLocal)))
-    #define YY_DECL int yylex(YYSTYPE* pyylval, void* parseContextLocal)
-    #define YYLEX_PARAM (void*)(parseContextLocal)
-    extern void yyerror(const char*);
-#endif
-
+extern void yyerror(TParseContext&, const char*);
 
 #define FRAG_ONLY(S, L) {                                                       \
     if (parseContext.language != EShLangFragment) {                             \
@@ -102,11 +89,13 @@ Jutta Degener, 1995
 
 %{
 #ifndef _WIN32
-    extern int yylex(YYSTYPE*, void*);
+    extern int yylex(YYSTYPE*, TParseContext&);
 #endif
 %}
 
-%pure_parser /* Just in case is called from multiple threads */
+%parse-param { TParseContext& parseContext}
+%lex-param { TParseContext& parseContext }
+%define api.pure full
 %expect 1 /* One shift reduce conflict because of if | else */
 %token <lex> CONST_QUAL STATIC_QUAL BOOL_TYPE FLOAT_TYPE INT_TYPE STRING_TYPE FIXED_TYPE HALF_TYPE
 %token <lex> BREAK CONTINUE DO ELSE FOR IF DISCARD RETURN


### PR DESCRIPTION
There were some odd platform-specific macro checks... I removed these
since hours of trying to figure out the purpose of them bore fruitless.

YYPARSE_PARAM and YYLEX_PARAM are both deprecated. We must now use parser
parameters in order to change the parameters.

yyerror oddly didn't require a contextual parameter despite bison being set
as a pure parser. We now accept the contextual parameter but do nothing with it.
I'm not sure how this was done and I'm not aware of a way to bring back that
functionality.

%pure_parser has been a deprecated parameter for years.
We now use %define api.pure full.

Please do not pull blindly. I cannot fully test this patch. I need people to test. 