### PR TITLE
Explicitly request a context version.

### DIFF
--- a/tests/hlsl2glsltest/hlsl2glsltest.cpp
+++ b/tests/hlsl2glsltest/hlsl2glsltest.cpp
@@ -75,7 +75,7 @@ static void logf(const char* format, ...)
 #include <dirent.h>
 #include <string.h>
 #include <GL/glew.h>
-#include <GL/glut.h>
+#include <GL/freeglut.h>
 
 #endif
 #include "../../include/hlsl2glsl.h"
@@ -259,9 +259,25 @@ static bool InitializeOpenGL ()
 #else
         int argc = 0;
         char** argv = NULL;
+
         glutInit(&argc, argv);
-        glutCreateWindow("hlsl2glsltest");
+        int tmp_window = glutCreateWindow("hlsl2glsltest");
+
         glewInit();
+
+        if (GLEW_VERSION_3_2) { /* GLSL 1.5 */
+        	glutInitContextVersion(3, 2);
+        } else if (GLEW_VERSION_3_1) { /* GLSL 1.4 */
+        	glutInitContextVersion(3, 1);
+        } else if (GLEW_VERSION_2_1) { /* GLSL 1.2 */
+        	glutInitContextVersion(2, 1);
+        }
+
+        glutInitContextProfile(GLUT_CORE_PROFILE);
+
+        glutDestroyWindow(tmp_window);
+        glutCreateWindow("hlsl2glsltest");
+
 #endif
 	
 	// check if we have GLSL


### PR DESCRIPTION
Mesa doesn't support ARB_compatibility. It also doesn't default to the latest context. We can either make a context, test GL_VERSION, and parse the result... or just use GLEW and test versions until we get a minimum of each level we need for a given GLSL version.

Alternatively, we can get rid of freeglut and create a GLX/Xlib context with pixmap. I don't really think it's worth the trouble though... 

The code looks odd but it's easy to explain. glew is ahead of freeglut window initialization because glew requires a context to work. This context isn't created in glutInit but glutCreateWindow. We also have no way to create a context with the desired settings... so we create a dummy context to fetch capabilities, set the capabilities, destroy the dummy context/window, and create a new context/window with desired settings.  A core profile is required because Mesa does not support ARB_compatibility. 