### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/hlslang/Include/Common.h
+++ b/hlslang/Include/Common.h
@@ -29,6 +29,7 @@
 #include <string>
 #include <stdio.h>
 #include <sstream>
+#include <new>
 
 #include <assert.h>
 

--- a/hlslang/MachineIndependent/ParseHelper.cpp
+++ b/hlslang/MachineIndependent/ParseHelper.cpp
@@ -7,7 +7,7 @@
 #include "../Include/InitializeParseContext.h"
 #include "osinclude.h"
 #include <stdarg.h>
-
+#include <new>
 
 // ------------------------------------------------------------------
 
@@ -1914,11 +1914,13 @@ bool InitializeGlobalParseContext()
       return false;
    }
 
-   TThreadParseContext *lpThreadData = new TThreadParseContext();
-   if (lpThreadData == 0)
-   {
-      assert(0 && "InitializeGlobalParseContext(): Unable to create thread parse context");
-      return false;
+   TThreadParseContext *lpThreadData;
+   try {
+	   lpThreadData = new TThreadParseContext();
+   }
+   catch (std::bad_alloc& ba) {
+	   assert(0 && "InitializeGlobalParseContext(): Unable to create thread parse context");
+	   return false;
    }
 
    lpThreadData->lpGlobalParseContext = 0;

--- a/hlslang/MachineIndependent/PoolAlloc.cpp
+++ b/hlslang/MachineIndependent/PoolAlloc.cpp
@@ -218,9 +218,14 @@ void* TPoolAllocator::allocate(size_t numBytes)
       // The OS is efficient and allocating and free-ing multiple pages.
       //
       size_t numBytesToAlloc = allocationSize + headerSkip;
-      AllocHeader* memory = reinterpret_cast<AllocHeader*>(::new char[numBytesToAlloc]);
-      if (memory == 0)
-         return 0;
+	  AllocHeader* memory;
+
+	  try {
+		  memory = reinterpret_cast<AllocHeader*>(::new char[numBytesToAlloc]);
+	  }
+	  catch (std::bad_alloc& ba) {
+		  return 0;
+	  }
 
       // Use placement-new to initialize header
       new(memory) AllocHeader(inUseList, (numBytesToAlloc + pageSize - 1) / pageSize);
@@ -242,9 +247,12 @@ void* TPoolAllocator::allocate(size_t numBytes)
    }
    else
    {
-      memory = reinterpret_cast<AllocHeader*>(::new char[pageSize]);
-      if (memory == 0)
-         return 0;
+	   try {
+		   memory = reinterpret_cast<AllocHeader*>(::new char[pageSize]);
+	   }
+	   catch (std::bad_alloc& ba) {
+		   return 0;
+	   }
    }
 
    // Use placement-new to initialize header


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

V668 There is no sense in testing the 'memory' pointer against null, as the memory was allocated using the 'new' operator. The exception will be generated in the case of memory allocation error. poolalloc.cpp 222
V668 There is no sense in testing the 'memory' pointer against null, as the memory was allocated using the 'new' operator. The exception will be generated in the case of memory allocation error. poolalloc.cpp 246
V668 There is no sense in testing the 'lpThreadData' pointer against null, as the memory was allocated using the 'new' operator. The exception will be generated in the case of memory allocation error. parsehelper.cpp 1918