### PR TITLE
 fixed from PVS-Studio

### DIFF
--- a/hlslang/GLSLCodeGen/glslOutput.cpp
+++ b/hlslang/GLSLCodeGen/glslOutput.cpp
@@ -1898,6 +1898,7 @@ GlslStruct *TGlslOutputTraverser::createStructFromType (TType *type)
                                             (it->type->getBasicType() == EbtStruct) ? createStructFromType(it->type) : NULL,
                                              structName);
          s->addMember(*m);
+		 delete m;
       }
 
       //add it to the list

--- a/hlslang/MachineIndependent/Intermediate.cpp
+++ b/hlslang/MachineIndependent/Intermediate.cpp
@@ -216,8 +216,10 @@ TIntermTyped* ir_add_binary_math(TOperator op, TIntermTyped* left, TIntermTyped*
 	
 	node->setLeft(left);
 	node->setRight(right);
-	if (! node->promote(ctx))
+	if (!node->promote(ctx)) {
+		delete node;
 		return 0;
+	}
 	
 	//
 	// See if we can fold constants
@@ -253,8 +255,10 @@ TIntermTyped* ir_add_assign(TOperator op, TIntermTyped* left, TIntermTyped* righ
    node->setLine(line);
 
    TIntermTyped* child = ir_add_conversion(op, left->getType(), right, ctx.infoSink);
-   if (child == 0)
-      return 0;
+   if (child == 0) {
+	   delete node;
+	   return 0;
+   }
 
    node->setLeft(left);
    node->setRight(child);
@@ -361,8 +365,10 @@ TIntermTyped* ir_add_unary_math(TOperator op, TIntermNode* childNode, TSourceLoc
    node->setLine(line);
    node->setOperand(child);
 
-   if (! node->promote(ctx))
-      return 0;
+   if (!node->promote(ctx)) {
+	   delete node;
+	   return 0;
+   }
 	
 	
 	//
@@ -775,9 +781,10 @@ TIntermTyped* ir_add_selection(TIntermTyped* cond, TIntermTyped* trueBlock, TInt
    TIntermSelection* node = new TIntermSelection(cond, trueBlock, falseBlock, trueBlock->getType());
    node->setLine(line);
 
-    if (!node->promoteTernary(infoSink))
-        return 0;
-
+   if (!node->promoteTernary(infoSink)) {
+	   delete node;
+	   return 0;
+   }
 
    return node;
 }

--- a/hlslang/MachineIndependent/Intermediate.cpp
+++ b/hlslang/MachineIndependent/Intermediate.cpp
@@ -262,8 +262,10 @@ TIntermTyped* ir_add_assign(TOperator op, TIntermTyped* left, TIntermTyped* righ
 
    node->setLeft(left);
    node->setRight(child);
-   if (! node->promote(ctx))
-      return 0;
+   if (!node->promote(ctx)) {
+	   delete node;
+	   return 0;
+   }
 
    return node;
 }

--- a/tests/hlsl2glsltest/hlsl2glsltest.cpp
+++ b/tests/hlsl2glsltest/hlsl2glsltest.cpp
@@ -286,7 +286,7 @@ static bool InitializeOpenGL ()
 	}
 #endif
 	
-
+	ReleaseDC(wnd, dc);
 	return hasGLSL;
 }
 


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

V773 The function was exited without releasing the 'node' pointer. A memory leak is possible. intermediate.cpp
V773 Visibility scope of the 'm' pointer was exited without releasing the memory. A memory leak is possible. glsloutput.cpp 1901
V773 The function was exited without releasing the 'dc' handle. A resource leak is possible. hlsl2glsltest.cpp 290